### PR TITLE
1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DiscordSchematicUploader allows users to upload and download WorldEdit schematic
 ## Installing
 DiscordSchematicUploader requires WorldEdit (or one of its forks) and DiscordSRV to function. You will need these before going any further.
 
-Installation itself is simple, simply drag and drop the plugin into your plugins folder. Once you have done this, restart your server.
+Installation itself is easy, simply drag and drop the plugin into your plugins folder. Once you have done this, restart your server.
 
 The plugin should create a config.yml file which you can edit to change some settings and messages for the plugin. One of the first things you will need to do is add to the list of allowed roles for the upload and download commands. The comments and examples in the config will explain how to do this.
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ The plugin should create a config.yml file which you can edit to change some set
 `!download <name>`: Download a schematic from the server.
 
 ![](https://i.imgur.com/hJ9GoD4.png)
+
+## Schematic Upload Channels
+This plugin allows you to designate channels where any schematic file that is uploaded will be automatically processed, regardless of whether a command is run.
+
+![image](https://user-images.githubusercontent.com/67452089/147857856-9e1c01af-9f89-4dec-bcf7-fa1d721fe6e2.png)

--- a/src/main/java/io/github/dinty1/discordschematicuploader/DiscordSchematicUploader.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/DiscordSchematicUploader.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 public class DiscordSchematicUploader extends JavaPlugin {
 
     private boolean updateAvailable = false;
+    private final UploadChannelManager uploadChannelManager = new UploadChannelManager(this);
 
     public static DiscordSchematicUploader getPlugin() {
         return getPlugin(DiscordSchematicUploader.class);
@@ -43,6 +44,10 @@ public class DiscordSchematicUploader extends JavaPlugin {
 
     public boolean isUpdateAvailable() {
         return this.updateAvailable;
+    }
+
+    public UploadChannelManager getUploadChannelManager() {
+        return this.uploadChannelManager;
     }
 
     @Override

--- a/src/main/java/io/github/dinty1/discordschematicuploader/UploadChannelManager.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/UploadChannelManager.java
@@ -1,0 +1,75 @@
+/*-
+ * LICENSE
+ * DiscordSchematicUploader
+ * -------------
+ * Copyright (C) 2021 - 2022 Dinty1
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package io.github.dinty1.discordschematicuploader;
+
+import github.scarsz.discordsrv.dependencies.emoji.Emoji;
+import github.scarsz.discordsrv.dependencies.jda.api.entities.Message;
+import github.scarsz.discordsrv.dependencies.jda.api.entities.TextChannel;
+import io.github.dinty1.discordschematicuploader.util.ConfigUtil;
+import io.github.dinty1.discordschematicuploader.util.MessageUtil;
+import io.github.dinty1.discordschematicuploader.util.RoleUtil;
+
+import java.awt.*;
+import java.io.File;
+
+public class UploadChannelManager {
+
+    final DiscordSchematicUploader plugin;
+
+    public UploadChannelManager(DiscordSchematicUploader plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean isUploadChannel(TextChannel channel) {
+        return plugin.getConfig().getStringList("upload-channels").contains(channel.getId());
+    }
+
+    public void processMessageInUploadChannel(Message message, File schematicFolder) {
+        if (!MessageUtil.schematicAttached(message)) return;
+        if (!RoleUtil.hasAllowedRole(message.getMember(), plugin.getConfig().getStringList("upload-channels-allowed-roles")))
+            return;
+
+        final Message.Attachment attachment = message.getAttachments().get(0);
+
+        // Make sure the schematic doesn't already exist
+        final File downloadedSchematic = new File(schematicFolder, attachment.getFileName());
+        final boolean allowedToOverwrite = RoleUtil.hasAllowedRole(message.getMember(), plugin.getConfig().getStringList("upload-command-allowed-to-overwrite"));
+        if (downloadedSchematic.exists()) {
+            final String overwriteMessage = allowedToOverwrite ? " " + ConfigUtil.Message.UPLOAD_CHANNELS_CAN_OVERWRITE : "";
+            message.getChannel().sendMessage(MessageUtil.createEmbedBuilder(Color.RED, message.getAuthor(), ConfigUtil.Message.UPLOAD_CHANNELS_SCHEMATIC_ALREADY_EXISTS.toString(attachment.getFileName()) + overwriteMessage).build()).queue();
+            if (plugin.getConfig().getBoolean("upload-channels-delete-original-message")) message.delete().queue();
+            return;
+        }
+        try {
+            attachment.downloadToFile(downloadedSchematic);
+            plugin.getLogger().info(String.format("User %s (%s) uploaded schematic %s.", message.getAuthor().getAsTag(), message.getAuthor().getId(), attachment.getFileName()));
+            message.addReaction("\u2705").queue();
+        } catch (Exception e) {
+            plugin.getLogger().severe(e.getMessage());
+            e.printStackTrace();
+            message.getChannel().sendMessage(MessageUtil.createEmbedBuilder(Color.RED, message.getAuthor(), ConfigUtil.Message.UPLOAD_CHANNELS_UPLOAD_ERROR.toString()).build()).queue();
+        }
+
+        if (plugin.getConfig().getBoolean("upload-channels-delete-original-message")) message.delete().queue();
+    }
+}

--- a/src/main/java/io/github/dinty1/discordschematicuploader/discordcommand/UploadCommand.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/discordcommand/UploadCommand.java
@@ -57,6 +57,7 @@ public class UploadCommand {
                     } else {
                         final String overwriteMessage = allowedToOverwrite ? " " + ConfigUtil.Message.UPLOAD_COMMAND_CAN_OVERWRITE : "";
                         sentMessage.editMessage(MessageUtil.createEmbedBuilder(Color.RED, message.getAuthor(), ConfigUtil.Message.UPLOAD_COMMAND_SCHEMATIC_ALREADY_EXISTS.toString(attachment.getFileName()) + overwriteMessage).build()).queue();
+                        if (plugin.getConfig().getBoolean("upload-command-delete-original-message")) message.delete().queue();
                         return;
                     }
                 }
@@ -70,6 +71,7 @@ public class UploadCommand {
                     sentMessage.editMessage(MessageUtil.createEmbedBuilder(Color.RED, message.getAuthor(), ConfigUtil.Message.UPLOAD_COMMAND_ERROR.toString()).build()).queue();
                 }
 
+                if (plugin.getConfig().getBoolean("upload-command-delete-original-message")) message.delete().queue();
             });
         }
     }

--- a/src/main/java/io/github/dinty1/discordschematicuploader/listener/DiscordMessageListener.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/listener/DiscordMessageListener.java
@@ -82,7 +82,10 @@ public class DiscordMessageListener {
 
         Message message = event.getMessage();
 
-        if (!isValidCommand(event.getMessage().getContentRaw())) return;
+        if (!isValidCommand(event.getMessage().getContentRaw())) {
+            if (plugin.getUploadChannelManager().isUploadChannel(event.getChannel())) plugin.getUploadChannelManager().processMessageInUploadChannel(message, schematicFolder);
+            return;
+        }
 
         if (!channelIsAllowed(event.getChannel())) {
             plugin.getLogger().info(String.format("Ignoring command from %s in channel %s because the plugin is configured to not allow commands in this channel.",

--- a/src/main/java/io/github/dinty1/discordschematicuploader/util/ConfigUtil.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/util/ConfigUtil.java
@@ -93,6 +93,10 @@ public class ConfigUtil {
         UPLOAD_COMMAND_SUCCESS("upload-command-success"),
         UPLOAD_COMMAND_ERROR("upload-command-error"),
 
+        UPLOAD_CHANNELS_SCHEMATIC_ALREADY_EXISTS("upload-channels-schematic-already-exists"),
+        UPLOAD_CHANNELS_CAN_OVERWRITE("upload-channels-can-overwrite"),
+        UPLOAD_CHANNELS_UPLOAD_ERROR("upload-channels-upload-error"),
+
         DOWNLOAD_COMMAND_NO_PERMISSION("download-command-no-permission"),
         DOWNLOAD_COMMAND_NO_NAME_SPECIFIED("download-command-no-name-specified"),
         DOWNLOAD_COMMAND_SCHEMATIC_NOT_FOUND("download-command-schematic-not-found"),

--- a/src/main/java/io/github/dinty1/discordschematicuploader/util/MessageUtil.java
+++ b/src/main/java/io/github/dinty1/discordschematicuploader/util/MessageUtil.java
@@ -23,6 +23,7 @@
 package io.github.dinty1.discordschematicuploader.util;
 
 import github.scarsz.discordsrv.dependencies.jda.api.EmbedBuilder;
+import github.scarsz.discordsrv.dependencies.jda.api.entities.Message;
 import github.scarsz.discordsrv.dependencies.jda.api.entities.User;
 
 import java.awt.*;
@@ -37,5 +38,11 @@ public class MessageUtil {
         embedBuilder.setTitle(title);
 
         return embedBuilder;
+    }
+
+    public static boolean schematicAttached(Message message) {
+        if (message.getAttachments().size() == 0) return false;
+        final Message.Attachment attachment = message.getAttachments().get(0);
+        return attachment.getFileExtension() != null && (attachment.getFileExtension().equals("schem") || attachment.getFileExtension().equals("schematic"));
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,8 @@ config-version: ${project.version}
 # Whether the plugin should check for new available versions and notify admins that one is available
 update-check: true
 #
+# UPLOAD COMMAND
+#
 # What the command for uploading a schematic should be
 upload-command: "!upload"
 #
@@ -24,6 +26,8 @@ upload-command-allowed-to-overwrite: ["Staff"]
 #
 # Whether to delete the original message (the command and attached file) once the upload command has been processed
 upload-command-delete-original-message: false
+#
+# DOWNLOAD COMMAND
 #
 # What the command for downloading a schematic should be (the format is <command> <schematic name>)
 download-command: "!download"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,7 +22,7 @@ upload-command-allowed-roles: ["Builder", "Staff"]
 # Roles that are allowed to replace existing schematics when uploading one with the same name
 upload-command-allowed-to-overwrite: ["Staff"]
 #
-# Whether to delete the original message once the command has been processed
+# Whether to delete the original message (the command and attached file) once the upload command has been processed
 upload-command-delete-original-message: false
 #
 # What the command for downloading a schematic should be (the format is <command> <schematic name>)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,7 +12,7 @@ config-version: ${project.version}
 # Whether the plugin should check for new available versions and notify admins that one is available
 update-check: true
 #
-# UPLOAD COMMAND
+# UPLOAD COMMAND - Settings for the command to upload a schematic
 #
 # What the command for uploading a schematic should be
 upload-command: "!upload"
@@ -27,7 +27,18 @@ upload-command-allowed-to-overwrite: ["Staff"]
 # Whether to delete the original message (the command and attached file) once the upload command has been processed
 upload-command-delete-original-message: false
 #
-# DOWNLOAD COMMAND
+# UPLOAD CHANNELS - Settings for channels where any schematic file sent will automatically be uploaded, regardless of message content
+#
+upload-channels: ["00000000000000000", "00000000000000000"]
+#
+# Roles that are allowed to upload schematics in this way (anyone without one of these roles will be ignored). Role names and IDs are both acceptable.
+# If you wish to allow all users access to the feature, set this option to ["@everyone"]
+upload-channels-allowed-roles: ["Builder", "Staff"]
+#
+# Whether to delete messages that contain schematic files once they have been processed
+upload-channels-delete-original-message: false
+#
+# DOWNLOAD COMMAND - Settings for the command to download a schematic
 #
 # What the command for downloading a schematic should be (the format is <command> <schematic name>)
 download-command: "!download"
@@ -42,7 +53,9 @@ send-downloaded-schematic-privately: false
 # Whether the channel whitelist is enabled (see below)
 channel-whitelist-enabled: false
 #
-# Channel whitelist: A list of channel IDs where commands can be run (commands in all other channels will be ignored)
+# CHANNEL WHITELIST - Settings for whitelisting/blacklisting certain channels for commands
+#
+# A list of channel IDs where commands can be run (commands in all other channels will be ignored)
 channel-whitelist: ["00000000000000000", "00000000000000000"]
 #
 # Whether the above option instead acts as a blacklist (commands will be accepted in all channels except the ones added)
@@ -62,7 +75,7 @@ upload-command-no-attachment: "You need to attach a file to upload."
 upload-command-invalid-schematic-file: "That's not a valid schematic file."
 # Shown when a schematic is being loaded onto the server
 upload-command-attempting-schematic-save: "Attempting to save schematic..."
-# Shown when a schematic by the name of the one being uploaded already exists
+# Shown when a schematic by the name of the one being uploaded already exists on the server
 upload-command-schematic-already-exists: "The schematic `%schematic%` already exists."
 # Added to the end of the previous message if the user has permission to overwrite schematics
 upload-command-can-overwrite: "You can replace the old file by adding `-o` to your message when sending the command."
@@ -70,6 +83,15 @@ upload-command-can-overwrite: "You can replace the old file by adding `-o` to yo
 upload-command-success: "Schematic successfully saved as `%schematic%`."
 # Shown when an unknown error occurs while loading the schematic (hopefully you won't have to see this)
 upload-command-error: "An error occurred when trying to save the schematic. Please check the server console for more details."
+#
+# Upload Channels
+#
+# Shown when a schematic by the name of the one being uploaded already exists on the server
+upload-channels-schematic-already-exists: "`%schematic%` already exists on the server."
+# Added to the end of the previous message if the user has permission to overwrite schematics
+upload-channels-can-overwrite: "You can replace the old file by sending `-o` after the upload command with the schematic attached"
+# Shown when an unknown error occurs while loading the schematic (hopefully you won't have to see this)
+upload-channels-upload-error: "An error occurred when trying to save the schematic. Please check the server console for more details."
 #
 # Download Command
 #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,7 @@
 # Please do not touch this
 config-version: ${project.version}
 #
-# Whether the plugin should check for new available versions
+# Whether the plugin should check for new available versions and notify admins that one is available
 update-check: true
 #
 # What the command for uploading a schematic should be

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,9 @@ upload-command-allowed-roles: ["Builder", "Staff"]
 # Roles that are allowed to replace existing schematics when uploading one with the same name
 upload-command-allowed-to-overwrite: ["Staff"]
 #
+# Whether to delete the original message once the command has been processed
+upload-command-delete-original-message: false
+#
 # What the command for downloading a schematic should be (the format is <command> <schematic name>)
 download-command: "!download"
 #


### PR DESCRIPTION
- Added a config option to delete the upload command and attached schematic once processed.
- Added support for schematic upload channels, where any schematic uploaded will be automatically processed without needing to be in a command.

N.B. All versions of the plugin are fully compatible with 1.16, 1.17 and 1.18